### PR TITLE
Fixed relative path in copy action

### DIFF
--- a/dpat.py
+++ b/dpat.py
@@ -114,7 +114,7 @@ class HtmlBuilder:
 
     def write_html_report(self, filename):
         f = open(os.path.join(folder_for_html_report, filename), "w")
-        copyfile('report.css', os.path.join(folder_for_html_report, "report.css"))
+        copyfile(os.path.join(os.path.dirname(__file__), "report.css"), os.path.join(folder_for_html_report, "report.css"))
         f.write(self.get_html())
         f.close()
         return filename


### PR DESCRIPTION
When DPAT is in the PATH environment variable, `report.css` was copied from the CWD instead of the path where DPAT is located.