### PR TITLE
Fixed SyntaxWarning: "is" with a literal.

### DIFF
--- a/dpat.py
+++ b/dpat.py
@@ -517,7 +517,7 @@ print('Would you like to open the report now? [Y/n]')
 while True:
     try:
         response = input().lower().rstrip('\r')
-        if ((response is "") or (strtobool(response))):
+        if ((response == "") or (strtobool(response))):
             webbrowser.open(os.path.join("file://" + os.getcwd(),
                                          folder_for_html_report, filename_for_html_report))
             break


### PR DESCRIPTION
Code would throw a syntax warning, as included below.

```/Users/tijme/Workspace/Tools/pub-dpat/./resources/dpat.py:520: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if ((response is "") or (strtobool(response))):```