### PR TITLE
Fix groups in domain\username format

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,20 @@ Alternatively, the group files can simply be a list of users, one per line, in t
 
 >domain\username
 
-[Here](https://gist.githubusercontent.com/joswr1ght/c557f8627832d54458c810e43be9c055/raw/b46e5e976196a20e7ecfe88da7d7a22c747d64e0/groupenumeration.ps1) is a PowerShell one-liner to create group files for all groups.
+Here is a small PowerShell script to create "Schema Admins.txt" 
+```sh
+$GroupName = "Schema Admins"
+$UPNS = Get-ADGroupMember -Identity $GroupName -Recursive | % {Get-ADUser $_.samaccountname|select userprincipalname -ExpandProperty userprincipalname}
+$UPNS = $UPNS| Sort-Object | Get-Unique
+$output = @()
+foreach ($UPN in $UPNS) {
+    $user, $domain = $UPN -split '@'
+    $fqdn = $domain + '\' + $user
+    $output += $fqdn
+    }
+$file = $GroupName + ".txt"
+$output | Out-File  -filepath $file
+```
 
 The Domain Password Audit Tool also has the handy feature to finish cracking the LM hashes for any hashes where the NT hash was not cracked. This asssumes that you have used Hashcat to brute force all 7 character passwords with the following command:
 

--- a/dpat.py
+++ b/dpat.py
@@ -191,17 +191,22 @@ if not speed_it_up:
                 if "MemberName" in line:
                     user_name = (line.split(":")[1]).strip()
                     users.append(user_domain + "\\" + user_name)
-        except:
-            print("Doesn't look like the Group Files are in the form output by PowerView, assuming the files are already in domain\\username list form")
-            # If the users array is empty, assume the file was not in the PowerView PowerShell script output format that you get from running:
-            # Get-NetGroupMember -GroupName "Enterprise Admins" -Domain "some.domain.com" -DomainController "DC01.some.domain.com" > Enterprise Admins.txt
-            # You can list domain controllers for use in the above command with Get-NetForestDomain
-            if len(users) == 0:
-                fing = open(group[1])
-                users = []
+            if len(users) != 0:
+                fing.close()
+            else:
+                print("Doesn't look like the Group Files are in the form output by PowerView, assuming the files are already in domain\\username list form")
+                # If the users array is empty, assume the file was not in the PowerView PowerShell script output format that you get from running:
+                # Get-NetGroupMember -GroupName "Enterprise Admins" -Domain "some.domain.com" -DomainController "DC01.some.domain.com" > Enterprise Admins.txt
+                # You can list domain controllers for use in the above command with Get-NetForestDomain
+            
+                fing.seek(0)
+                # Reset File pointer to first line and try again
                 for line in fing:
                     users.append(line.rstrip("\n"))
                 fing.close()
+        except:
+            fing.close()
+            print("unknown exception while processing group file(s)")
         groups_users[group[0]] = users
 
     # Read in NTDS file


### PR DESCRIPTION
Move case for files in domain\\user format out of catch block so it can be executed. Add small PS script to README and remove link to gist that doesn't include domain in files.